### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
-#skilltree
+# skilltree
 
 Build your own skill tree similar to [DungeonsAndDevelopers.com](http://www.DungeonsAndDevelopers.com)!
 
-###Before you start
+### Before you start
 
 This app uses Steve Sanderson's awesome [Knockout.js](http://knockoutjs.com/) framework extensively. Knockout provides a fun, low-barrier entry to MVVM concepts. If this is all new to you, check out the [tutorial](http://learn.knockoutjs.com/).
 
 (Psst! After you're done messing with this project, check out [Google's Angular.js](http://angularjs.org/) for another perspective.)
 
-###Building skilltree.min.js
+### Building skilltree.min.js
 
 The */src* folder contains a file called *skilltree.js*. You can use a compiler like [CodeKit](http://incident57.com/codekit/) or [Prepos](http://alphapixels.com/prepros/) to uglify this to *dist/skilltree.min.js*. (You will probably need to alter the output path.)
 
-###What's *not* in here?
+### What's *not* in here?
 * Any server side code or database stuff. We're keeping it simple!
 * Styling. I'm open to ideas on how to handle the skill positions and dependency arrows, provided it doesn't look lame and still gives the designer flexibility. A secondary optional class for auto-positioning might be a decent solution...
 
-###Demos
+### Demos
 The */demos* folder contains */dungeons-and-developers*, which is probably what brought you here. I've split it out with the hope that you'll be able to use the skilltree script independendently for your own project, and even add your own to the demos folder, if you wish. 
 
 **Please do, I'd love to see what you make!**
 
-##License
+## License
 
 MIT license - [http://www.opensource.org/licenses/mit-license.php](http://www.opensource.org/licenses/mit-license.php)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
